### PR TITLE
Fix server compatibility with ComputerCraft peripherals

### DIFF
--- a/src/main/java/com/brandon3055/draconicevolution/blocks/reactor/tileentity/TileReactorCore.java
+++ b/src/main/java/com/brandon3055/draconicevolution/blocks/reactor/tileentity/TileReactorCore.java
@@ -552,6 +552,8 @@ public class TileReactorCore extends TileBCore implements ITickableTileEntity, I
         if (level.isClientSide) {
             LogHelper.dev("Reactor: Start Charging");
             sendPacketToServer(output -> output.writeByte(ID_CHARGE), 0);
+        } else if (!level.getServer().isSameThread()) {
+            level.getServer().executeBlocking(this::chargeReactor);
         } else if (canCharge()) {
             LogHelper.dev("Reactor: Start Charging");
             reactorState.set(ReactorState.WARMING_UP);
@@ -562,6 +564,8 @@ public class TileReactorCore extends TileBCore implements ITickableTileEntity, I
         if (level.isClientSide) {
             LogHelper.dev("Reactor: Activate");
             sendPacketToServer(output -> output.writeByte(ID_ACTIVATE), 0);
+        } else if (!level.getServer().isSameThread()) {
+            level.getServer().executeBlocking(this::activateReactor);
         } else if (canActivate()) {
             LogHelper.dev("Reactor: Activate");
             reactorState.set(ReactorState.RUNNING);
@@ -885,7 +889,6 @@ public class TileReactorCore extends TileBCore implements ITickableTileEntity, I
             if (!Utils.isAreaLoaded(level, pos, LocationType.TICKING)) {
                 return true;
             }
-
 
             TileEntity tile = level.getBlockEntity(pos);
             LogHelper.dev("Reactor: Validate Stabilizer: " + tile);

--- a/src/main/java/com/brandon3055/draconicevolution/integration/computers/PeripheralReactorComponent.java
+++ b/src/main/java/com/brandon3055/draconicevolution/integration/computers/PeripheralReactorComponent.java
@@ -70,7 +70,7 @@ public class PeripheralReactorComponent implements IPeripheral, ICapabilityProvi
 	@LuaFunction
 	public final boolean chargeReactor() {
 		if (refreshCoreStatus()) {
-            reactor.sendPacketToServer(output -> output.writeByte(TileReactorCore.ID_CHARGE), 0);
+			reactor.chargeReactor();
             return true;
         }
         return false;
@@ -79,7 +79,7 @@ public class PeripheralReactorComponent implements IPeripheral, ICapabilityProvi
 	@LuaFunction
 	public final boolean activateReactor() {
 		if (refreshCoreStatus()) {
-			reactor.sendPacketToServer(output -> output.writeByte(TileReactorCore.ID_ACTIVATE), 0);
+			reactor.activateReactor();
             return true;
         }
         return false;
@@ -88,7 +88,7 @@ public class PeripheralReactorComponent implements IPeripheral, ICapabilityProvi
 	@LuaFunction
 	public final boolean stopReactor() {
 		if (refreshCoreStatus()) {
-			reactor.sendPacketToServer(output -> output.writeByte(TileReactorCore.ID_SHUTDOWN), 0);
+			reactor.shutdownReactor();
             return true;
         }
         return false;
@@ -97,7 +97,7 @@ public class PeripheralReactorComponent implements IPeripheral, ICapabilityProvi
 	@LuaFunction
 	public final boolean toggleFailSafe() {
 		if (refreshCoreStatus()) {
-			reactor.sendPacketToServer(output -> output.writeByte(TileReactorCore.ID_FAIL_SAFE), 0);
+			reactor.toggleFailSafe();
 			return true;
 		}
 		return false;


### PR DESCRIPTION
Fixes an issue when using ComputerCraft on a standalone forge server to control a reactor.

How to reproduce:
1. in minecraft 1.16.5 on forge install mods: BrandonsCore, DraconicEvolution, ComputerCraft
2. build a standard reactor
3. use the peripheral integration from DraconicEvolution via ComputerCraft to charge the reactor

My findings:
This issue seems to be caused by this mod always sending a packet even when on a server. CodeChickenLib only implements the sendToServer() method client-side which causes an exception.

Solution:
Don't send a packet and instead just run the logic. The mod runs the methods I used when receiving the specified packets from the client so it is safe to just use those methods. To ensure proper structure validation, it also must be ensured to do so on the main thread or else Minecraft will always return null instead of any blocks.

Exception:
`[19:38:23] [ComputerCraft-Coroutine-21/ERROR] [computercraft/]: Error calling call on dan200.computercraft.core.apis.PeripheralAPI@3e63c4ec
java.lang.NoSuchMethodError: codechicken.lib.packet.PacketCustom.sendToServer()V
        at com.brandon3055.brandonscore.blocks.TileBCore.sendPacketToServer(TileBCore.java:173) ~[brandonscore:1.16.5-3.0.12.240] {re:classloading}
        at com.brandon3055.draconicevolution.integration.computers.PeripheralReactorComponent.chargeReactor(PeripheralReactorComponent.java:73) ~[draconicevolution:1.16.5-3.0.20.440] {re:classloading}
        at com.brandon3055.draconicevolution.integration.computers.PeripheralReactorComponent$cc$chargeReactor135.apply(CC generated method) ~[?:?] {re:classloading,re:classloading,re:classloading,re:classloading,re:classloading,re:classloading}
        at dan200.computercraft.core.apis.PeripheralAPI$PeripheralWrapper.call(PeripheralAPI.java:112) ~[computercraft:1.100.2] {re:classloading}
        at dan200.computercraft.core.apis.PeripheralAPI.call(PeripheralAPI.java:361) ~[computercraft:1.100.2] {re:classloading}
        at dan200.computercraft.core.apis.PeripheralAPI$cc$call94.apply(CC generated method) ~[?:?] {re:classloading,re:classloading,re:classloading,re:classloading,re:classloading,re:classloading}
        at dan200.computercraft.core.lua.ResultInterpreterFunction.invoke(ResultInterpreterFunction.java:58) ~[computercraft:1.100.2] {re:classloading}
        at org.squiddev.cobalt.function.ResumableVarArgFunction.invoke(ResumableVarArgFunction.java:77) ~[computercraft:1.100.2] {re:classloading}
        at org.squiddev.cobalt.function.LuaInterpreter.execute(LuaInterpreter.java:491) ~[computercraft:1.100.2] {re:classloading}
        at org.squiddev.cobalt.function.LuaInterpretedFunction.resume(LuaInterpretedFunction.java:196) ~[computercraft:1.100.2] {re:classloading}
        at org.squiddev.cobalt.debug.DebugFrame.resume(DebugFrame.java:243) ~[computercraft:1.100.2] {re:classloading}
        at org.squiddev.cobalt.LuaThread.loop(LuaThread.java:566) ~[computercraft:1.100.2] {re:classloading}
        at org.squiddev.cobalt.LuaThread$1.run(LuaThread.java:463) ~[computercraft:1.100.2] {re:classloading}
        at dan200.computercraft.core.lua.CobaltLuaMachine.lambda$null$1(CobaltLuaMachine.java:80) ~[computercraft:1.100.2] {re:classloading}
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_332] {}
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_332] {}
        at java.lang.Thread.run(Thread.java:750) [?:1.8.0_332] {}`