### PR TITLE
Fix mob soul blacklist, check blacklist before spawning

### DIFF
--- a/src/main/java/com/brandon3055/draconicevolution/blocks/tileentity/StabilizedSpawnerLogic.java
+++ b/src/main/java/com/brandon3055/draconicevolution/blocks/tileentity/StabilizedSpawnerLogic.java
@@ -2,6 +2,7 @@ package com.brandon3055.draconicevolution.blocks.tileentity;
 
 import com.brandon3055.draconicevolution.init.DEContent;
 import com.brandon3055.draconicevolution.handlers.DEEventHandler;
+import com.brandon3055.draconicevolution.items.MobSoul;
 import net.minecraft.block.Blocks;
 import net.minecraft.entity.*;
 import net.minecraft.nbt.CompoundNBT;
@@ -139,6 +140,10 @@ public class StabilizedSpawnerLogic extends AbstractSpawner {
     }
 
     public boolean canEntitySpawnSpawner(MobEntity entity, World world, float x, float y, float z, AbstractSpawner spawner) {
+        if (!MobSoul.isValidEntity(entity)) {
+            return false;
+        }
+
         Event.Result result = ForgeEventFactory.canEntitySpawn(entity, world, x, y, z, spawner, SpawnReason.SPAWNER);
         if (result == Event.Result.DEFAULT) {
             return (tile.spawnerTier.get().ignoreSpawnReq() || entity.checkSpawnRules(world, SpawnReason.SPAWNER)) && entity.checkSpawnObstruction(world);

--- a/src/main/java/com/brandon3055/draconicevolution/handlers/DEEventHandler.java
+++ b/src/main/java/com/brandon3055/draconicevolution/handlers/DEEventHandler.java
@@ -11,6 +11,7 @@ import com.brandon3055.draconicevolution.api.energy.ICrystalBinder;
 import com.brandon3055.draconicevolution.entity.GuardianCrystalEntity;
 import com.brandon3055.draconicevolution.entity.guardian.DraconicGuardianEntity;
 import com.brandon3055.draconicevolution.init.DEContent;
+import com.brandon3055.draconicevolution.items.MobSoul;
 import com.brandon3055.draconicevolution.network.CrystalUpdateBatcher;
 import com.brandon3055.draconicevolution.utils.LogHelper;
 import net.minecraft.block.Blocks;
@@ -27,6 +28,7 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.util.Hand;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.Util;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.BlockRayTraceResult;
@@ -162,7 +164,7 @@ public class DEEventHandler {
     }
 
     private void handleSoulDrops(LivingDropsEvent event) {
-        if (event.getEntity().level.isClientSide || !(event.getSource().msgId.equals("player") || event.getSource().msgId.equals("arrow")) || !isValidEntity(event.getEntityLiving())) {
+        if (event.getEntity().level.isClientSide || !(event.getSource().msgId.equals("player") || event.getSource().msgId.equals("arrow")) || !MobSoul.isValidEntity(event.getEntityLiving())) {
             return;
         }
 
@@ -203,20 +205,6 @@ public class DEEventHandler {
 
         chance += EnchantmentHelper.getItemEnchantmentLevel(DEContent.reaperEnchant, stack);
         return chance;
-    }
-
-    private boolean isValidEntity(LivingEntity entity) {
-        if (!entity.canChangeDimensions() && !DEConfig.allowBossSouls) {
-            return false;
-        }
-        for (int i = 0; i < DEConfig.spawnerList.length; i++) {
-            if (DEConfig.spawnerList[i].equals(entity.getName()) && DEConfig.spawnerListWhiteList) {
-                return true;
-            } else if (DEConfig.spawnerList[i].equals(entity.getName()) && !DEConfig.spawnerListWhiteList) {
-                return false;
-            }
-        }
-        return !DEConfig.spawnerListWhiteList;
     }
 
     //endregion

--- a/src/main/java/com/brandon3055/draconicevolution/items/MobSoul.java
+++ b/src/main/java/com/brandon3055/draconicevolution/items/MobSoul.java
@@ -3,6 +3,7 @@ package com.brandon3055.draconicevolution.items;
 import com.brandon3055.brandonscore.items.ItemBCore;
 import com.brandon3055.brandonscore.utils.InventoryUtils;
 import com.brandon3055.brandonscore.utils.ItemNBTHelper;
+import com.brandon3055.draconicevolution.DEConfig;
 import com.brandon3055.draconicevolution.init.DEContent;
 import com.brandon3055.draconicevolution.client.handler.ClientEventHandler;
 import com.brandon3055.draconicevolution.utils.LogHelper;
@@ -276,5 +277,22 @@ public class MobSoul extends ItemBCore {
 
     public static ResourceLocation getCachedRegName(String name) {
         return rlCache.computeIfAbsent(name, ResourceLocation::new);
+    }
+
+    public static boolean isValidEntity(LivingEntity entity) {
+        ResourceLocation location = entity.getType().getRegistryName();
+        String registryName = location == null ? null : location.toString();
+
+        if (!entity.canChangeDimensions() && !DEConfig.allowBossSouls) {
+            return false;
+        }
+        for (int i = 0; i < DEConfig.spawnerList.length; i++) {
+            if (DEConfig.spawnerList[i].equals(registryName) && DEConfig.spawnerListWhiteList) {
+                return true;
+            } else if (DEConfig.spawnerList[i].equals(registryName) && !DEConfig.spawnerListWhiteList) {
+                return false;
+            }
+        }
+        return !DEConfig.spawnerListWhiteList;
     }
 }


### PR DESCRIPTION
1. Currently `DEEventHandler.isValidEntity` calls `String.equals` on an `ITextComponent` from `entity.getName()`, this always fails so the blacklist does not work. PR changes this to `entity.getType().getRegistryName().toString()`. 

This does have the side-effect of changing the blacklist to use registry IDs instead of whatever format `entity.getName()` returns, but since it didn't work before, this doesn't break anything. 

2. Also check `isValidEntity` on the powered spawner, so that mobs on the blacklist can't spawn even if the player got a soul for one previously.
