### PR TITLE
Fix the shader crash on Intel integrated graphics

### DIFF
--- a/src/main/resources/assets/draconicevolution/shaders/core/tools/bow_string.fsh
+++ b/src/main/resources/assets/draconicevolution/shaders/core/tools/bow_string.fsh
@@ -20,7 +20,7 @@ in vec4 lightMapColor;
 in vec4 overlayColor;
 in vec2 texCoord0;
 in vec4 normal;
-in vec4 vNorm;
+in vec3 vNorm;
 
 out vec4 fragColor;
 

--- a/src/main/resources/assets/draconicevolution/shaders/core/tools/chestpiece_gem.fsh
+++ b/src/main/resources/assets/draconicevolution/shaders/core/tools/chestpiece_gem.fsh
@@ -20,7 +20,7 @@ in vec4 lightMapColor;
 in vec4 overlayColor;
 in vec2 texCoord0;
 in vec4 normal;
-in vec4 vNorm;
+in vec3 vNorm;
 
 out vec4 fragColor;
 

--- a/src/main/resources/assets/draconicevolution/shaders/core/tools/chestpiece_shield.fsh
+++ b/src/main/resources/assets/draconicevolution/shaders/core/tools/chestpiece_shield.fsh
@@ -20,7 +20,7 @@ in vec4 lightMapColor;
 in vec4 overlayColor;
 in vec2 texCoord0;
 in vec4 normal;
-in vec4 vNorm;
+in vec3 vNorm;
 
 out vec4 fragColor;
 

--- a/src/main/resources/assets/draconicevolution/shaders/core/tools/tool_base.fsh
+++ b/src/main/resources/assets/draconicevolution/shaders/core/tools/tool_base.fsh
@@ -18,7 +18,7 @@ in vec4 lightMapColor;
 in vec4 overlayColor;
 in vec2 texCoord0;
 in vec4 normal;
-in vec4 vNorm;
+in vec3 vNorm;
 
 out vec4 fragColor;
 

--- a/src/main/resources/assets/draconicevolution/shaders/core/tools/tool_blade.fsh
+++ b/src/main/resources/assets/draconicevolution/shaders/core/tools/tool_blade.fsh
@@ -20,7 +20,7 @@ in vec4 lightMapColor;
 in vec4 overlayColor;
 in vec2 texCoord0;
 in vec4 normal;
-in vec4 vNorm;
+in vec3 vNorm;
 
 out vec4 fragColor;
 

--- a/src/main/resources/assets/draconicevolution/shaders/core/tools/tool_gem.fsh
+++ b/src/main/resources/assets/draconicevolution/shaders/core/tools/tool_gem.fsh
@@ -20,7 +20,7 @@ in vec4 lightMapColor;
 in vec4 overlayColor;
 in vec2 texCoord0;
 in vec4 normal;
-in vec4 vNorm;
+in vec3 vNorm;
 
 out vec4 fragColor;
 

--- a/src/main/resources/assets/draconicevolution/shaders/core/tools/tool_trace.fsh
+++ b/src/main/resources/assets/draconicevolution/shaders/core/tools/tool_trace.fsh
@@ -20,7 +20,7 @@ in vec4 lightMapColor;
 in vec4 overlayColor;
 in vec2 texCoord0;
 in vec4 normal;
-in vec4 vNorm;
+in vec3 vNorm;
 
 out vec4 fragColor;
 


### PR DESCRIPTION
This PR fixes the the shader compile crash on Intel integrated graphics (HD Graphics 520 for me). Essentially, the issue was that `tool_base.vsh` in `core/tools` was outputting `vNorm` as a `vec3` but the tools fragment shaders expected it as a `vec4`. For some reason it looks like some graphic card are fine with that, while other aren't. I have no idea if this was also the reason for the crashes on AMD graphic cards. I also do not own any previously compatible card, so someone should maybe test it in case it breaks something there.

PS: The shaders are beautiful :p