### PR TITLE
Fix broken link to the **Don't be a Jerk License**

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,5 @@ Draconic-Evolution
 Draconic Evolution adds powerful new tools, Items, weapons and Armor. The premise is the enigmatic ore - Draconium. As you progress you find it has many uses from the mundane such as machines and items, to the near-mystical at the top with Awakened Draconium to make extremely powerful armor and tools.
 
 ## License / Use in Modpacks
-This mod is licensed under the [**Don't Be a Jerk License**](https://github.com/brandon3055/Draconic-Evolution/blob/master/LICENSE) created by CoFH.
+This mod is licensed under the [**Don't Be a Jerk License**](https://github.com/brandon3055/Draconic-Evolution/blob/master/LICENSE.md) created by CoFH.
 I herby grant permission to use this mod in any mod pack without the need to request permission from myself the owner (brandon3055).


### PR DESCRIPTION
The current link goes to a folder that doesn't exist. This edit fixes that.