### PR TITLE
Update ComputerCraft integration to 1.20.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,10 @@ repositories {
     maven { url = "https://dvs1.progwml6.com/files/maven" }
     maven { url = "https://maven.cil.li/" }
     maven { url = "https://maven.theillusivec4.top/" }
-    maven { url = "https://squiddev.cc/maven/" }
+    maven { 
+        url = "https://maven.squiddev.cc/"
+        content { includeGroup("cc.tweaked") }
+    }
     maven { url = "https://maven.blamejared.com/" }
 //    maven { url = "https://modmaven.dev/" }
 }

--- a/src/main/java/com/brandon3055/draconicevolution/integration/computers/CCOCIntegration.java
+++ b/src/main/java/com/brandon3055/draconicevolution/integration/computers/CCOCIntegration.java
@@ -7,6 +7,9 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.CapabilityManager;
+import net.minecraftforge.common.capabilities.CapabilityToken;
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.fml.ModList;
 
@@ -17,25 +20,23 @@ import javax.annotation.Nullable;
  * Created by brandon3055 on 21/9/2015.
  */
 public class CCOCIntegration {
+    public static final Capability<IPeripheral> CAPABILITY_PERIPHERAL = CapabilityManager.get(new CapabilityToken<>() {
+    });
 
     public static void init() {
-        if (ModList.get().isLoaded("computercraft")) {
-            initCC();
-        }
         if (ModList.get().isLoaded("opencomputers")) {
             initOC();
         }
-    }
-
-//    @Optional.Method(modid = "computercraft")
-    public static void initCC() {
-//        ComputerCraftAPI.registerPeripheralProvider(new DEPeripheralProvider());
     }
 
 //    @Optional.Method(modid = "opencomputers")
     public static void initOC() {
 //        Driver.add(new OCAdapter());
 //        Driver.add(new OCExtendedRFAdapter());
+    }
+
+    public static boolean isPeripheral(Capability<?> capability) {
+        return CAPABILITY_PERIPHERAL != null && capability == CAPABILITY_PERIPHERAL;
     }
 
 //    public static class OCAdapter extends DriverSidedTileEntity {
@@ -64,34 +65,4 @@ public class CCOCIntegration {
 //        }
 //    }
 //
-    //Computercraft
-	public static class DEPeripheralProvider implements IPeripheralProvider {
-		private IPeripheral peripheral;
-		private LazyOptional<IPeripheral> holderPeripheral;
-		
-        /**
-         * Produce an peripheral implementation from a block location.
-         *
-         * @param world The world the block is in.
-         * @param pos   The position the block is at.
-         * @param side  The side to get the peripheral from.
-         * @return A peripheral, or {@code null} if there is not a peripheral here you'd like to handle.
-         * @see ComputerCraftAPI#registerPeripheralProvider(IPeripheralProvider)
-         */
-        @Nullable
-        @Override
-        public LazyOptional<IPeripheral> getPeripheral(@Nonnull Level world, @Nonnull BlockPos pos, @Nonnull Direction side) {
-            BlockEntity tile = world.getBlockEntity(pos);
-            if (tile instanceof IPeripheral) {
-            	setPeripheral((IPeripheral)tile);
-                return holderPeripheral;
-            }
-            else return null;
-        }
-        
-        protected void setPeripheral(IPeripheral peripheral) {
-            this.peripheral = peripheral;
-            this.holderPeripheral = LazyOptional.of(() -> peripheral);
-        }
-	}
 }

--- a/src/main/java/com/brandon3055/draconicevolution/integration/computers/PeripheralEnergyPylon.java
+++ b/src/main/java/com/brandon3055/draconicevolution/integration/computers/PeripheralEnergyPylon.java
@@ -31,20 +31,20 @@ public class PeripheralEnergyPylon implements IPeripheral, ICapabilityProvider {
 
 	@Override
 	public boolean equals(IPeripheral other) {
-		return false;
+		return other instanceof PeripheralEnergyPylon o && tile == o.tile;
 	}
 	
-	@LuaFunction
+	@LuaFunction(mainThread = true)
 	public final long getEnergyStored() {
 		return tile.opAdapter.getOPStored();
 	}
 	
-	@LuaFunction
+	@LuaFunction(mainThread = true)
 	public final long getMaxEnergyStored() {
 		return tile.opAdapter.getMaxOPStored();
 	}
 	
-	@LuaFunction
+	@LuaFunction(mainThread = true)
 	public final Map<Object, Object> getEnergyStoredInNotation() {
 		Map<Object, Object> map = new HashMap<Object, Object>();
 		String[] split = tile.getCore().energy.getScientific().split("E", 2);
@@ -53,7 +53,7 @@ public class PeripheralEnergyPylon implements IPeripheral, ICapabilityProvider {
 		return map;
 	}
 	
-	@LuaFunction
+	@LuaFunction(mainThread = true)
 	public final Map<Object, Object> getMaxEnergyStoredInNotation() {
 		Map<Object, Object> map = new HashMap<Object, Object>();
 		long maxEnergy = tile.opAdapter.getMaxOPStored();
@@ -63,7 +63,7 @@ public class PeripheralEnergyPylon implements IPeripheral, ICapabilityProvider {
 		return map;
 	}
 	
-	@LuaFunction
+	@LuaFunction(mainThread = true)
 	public final long getTransferPerTick() {
 		if (tile.coreOffset.isNull() || tile.getCore() == null) {
             return 0;
@@ -72,7 +72,7 @@ public class PeripheralEnergyPylon implements IPeripheral, ICapabilityProvider {
 		return io == null ? 0 : io.currentInput() - io.currentOutput();
 	}
 
-	@LuaFunction
+	@LuaFunction(mainThread = true)
 	public final long getInputPerTick() {
 		if (tile.coreOffset.isNull() || tile.getCore() == null) {
 			return 0;
@@ -81,7 +81,7 @@ public class PeripheralEnergyPylon implements IPeripheral, ICapabilityProvider {
 		return io == null ? 0 : io.currentInput();
 	}
 
-	@LuaFunction
+	@LuaFunction(mainThread = true)
 	public final long getOutputPerTick() {
 		if (tile.coreOffset.isNull() || tile.getCore() == null) {
 			return 0;
@@ -92,15 +92,16 @@ public class PeripheralEnergyPylon implements IPeripheral, ICapabilityProvider {
 	
 	@Override
 	public <T> LazyOptional<T> getCapability(Capability<T> cap, Direction side) {
-		//TODO?
-//		if (cap == Capabilities.CAPABILITY_PERIPHERAL) {
-//            if (self == null) self = LazyOptional.of(() -> this);
-//            return self.cast();
-//        }
-        return LazyOptional.empty();
+		if (CCOCIntegration.isPeripheral(cap)) {
+			if (self == null) self = LazyOptional.of(() -> this);
+			return self.cast();
+		}
+		return LazyOptional.empty();
 	}
 	
 	public void invalidate() {
-//        self = CapabilityUtil.invalidate(self);
+		if (self == null) return;
+		self.invalidate();
+		self = null;
     }
 }

--- a/src/main/java/com/brandon3055/draconicevolution/integration/computers/PeripheralFlowGate.java
+++ b/src/main/java/com/brandon3055/draconicevolution/integration/computers/PeripheralFlowGate.java
@@ -24,60 +24,61 @@ public class PeripheralFlowGate implements IPeripheral, ICapabilityProvider {
 
 	@Override
 	public boolean equals(IPeripheral other) {
-		return false;
+		return other instanceof PeripheralFlowGate o && tile == o.tile;
 	}
 	
-	@LuaFunction
+	@LuaFunction(mainThread = true)
 	public final long getFlow() {
 		return tile.getFlow();
 	}
 	
-	@LuaFunction
+	@LuaFunction(mainThread = true)
 	public final void setOverrideEnabled(boolean state) {
 		tile.flowOverridden.set(state);
 	}
 	
-	@LuaFunction
+	@LuaFunction(mainThread = true)
 	public final boolean getOverrideEnabled() {
 		return tile.flowOverridden.get();
 	}
 	
-	@LuaFunction
+	@LuaFunction(mainThread = true)
 	public final void setFlowOverride(long amount) {
 		tile.flowOverride.set(amount);
 	}
 	
-	@LuaFunction
+	@LuaFunction(mainThread = true)
 	public final void setSignalHighFlow(long amount) {
 		tile.maxFlow.set(amount);
 	}
 	
-	@LuaFunction
+	@LuaFunction(mainThread = true)
 	public final long getSignalHighFlow() {
 		return tile.maxFlow.get();
 	}
 	
-	@LuaFunction
+	@LuaFunction(mainThread = true)
 	public final void setSignalLowFlow(long amount) {
 		tile.minFlow.set(amount);
 	}
 	
-	@LuaFunction
+	@LuaFunction(mainThread = true)
 	public final long getSignalLowFlow() {
 		return tile.minFlow.get();
 	}
 
 	@Override
 	public <T> LazyOptional<T> getCapability(Capability<T> cap, Direction side) {
-		//TODO?
-//		if (cap == Capabilities.CAPABILITY_PERIPHERAL) {
-//            if (self == null) self = LazyOptional.of(() -> this);
-//            return self.cast();
-//        }
-        return LazyOptional.empty();
+		if (CCOCIntegration.isPeripheral(cap)) {
+			if (self == null) self = LazyOptional.of(() -> this);
+			return self.cast();
+		}
+		return LazyOptional.empty();
 	}
 	
 	public void invalidate() {
-//        self = CapabilityUtil.invalidate(self);
+		if (self == null) return;
+		self.invalidate();
+		self = null;
     }
 }

--- a/src/main/java/com/brandon3055/draconicevolution/integration/computers/PeripheralReactorComponent.java
+++ b/src/main/java/com/brandon3055/draconicevolution/integration/computers/PeripheralReactorComponent.java
@@ -31,7 +31,7 @@ public class PeripheralReactorComponent implements IPeripheral, ICapabilityProvi
 
 	@Override
 	public boolean equals(IPeripheral other) {
-		return false;
+		return other instanceof PeripheralReactorComponent o && tile == o.tile;
 	}
 	
 	private boolean refreshCoreStatus() {
@@ -42,7 +42,7 @@ public class PeripheralReactorComponent implements IPeripheral, ICapabilityProvi
         return true;
 	}
 
-	@LuaFunction
+	@LuaFunction(mainThread = true)
 	public final Map<Object, Object> getReactorInfo() {
 		if (refreshCoreStatus()) {
 			Map<Object, Object> map = new HashMap<Object, Object>();
@@ -63,7 +63,7 @@ public class PeripheralReactorComponent implements IPeripheral, ICapabilityProvi
 		return null;
 	}
 	
-	@LuaFunction
+	@LuaFunction(mainThread = true)
 	public final boolean chargeReactor() {
 		if (refreshCoreStatus()) {
 			reactor.chargeReactor();
@@ -72,7 +72,7 @@ public class PeripheralReactorComponent implements IPeripheral, ICapabilityProvi
         return false;
 	}
 	
-	@LuaFunction
+	@LuaFunction(mainThread = true)
 	public final boolean activateReactor() {
 		if (refreshCoreStatus()) {
 			reactor.activateReactor();
@@ -81,7 +81,7 @@ public class PeripheralReactorComponent implements IPeripheral, ICapabilityProvi
         return false;
 	}
 	
-	@LuaFunction
+	@LuaFunction(mainThread = true)
 	public final boolean stopReactor() {
 		if (refreshCoreStatus()) {
 			reactor.shutdownReactor();
@@ -90,7 +90,7 @@ public class PeripheralReactorComponent implements IPeripheral, ICapabilityProvi
         return false;
 	}
 	
-	@LuaFunction
+	@LuaFunction(mainThread = true)
 	public final boolean toggleFailSafe() {
 		if (refreshCoreStatus()) {
 			reactor.toggleFailSafe();
@@ -101,15 +101,16 @@ public class PeripheralReactorComponent implements IPeripheral, ICapabilityProvi
 	
 	@Override
 	public <T> LazyOptional<T> getCapability(Capability<T> cap, Direction side) {
-		//TODO Does CC still have caps?
-//		if (cap == Capabilities.CAPABILITY_PERIPHERAL) {
-//            if (self == null) self = LazyOptional.of(() -> this);
-//            return self.cast();
-//        }
-        return LazyOptional.empty();
+		if (CCOCIntegration.isPeripheral(cap)) {
+			if (self == null) self = LazyOptional.of(() -> this);
+			return self.cast();
+		}
+		return LazyOptional.empty();
 	}
 	
 	public void invalidate() {
-//        self = CapabilityUtil.invalidate(self);
+		if (self == null) return;
+		self.invalidate();
+		self = null;
     }
 }


### PR DESCRIPTION
This PR updates the ComputerCraft integration to 1.20.1, meaning flux gate, energy pylon, and reactor peripherals work again. Afraid I'd got most of the way through this before realising #1785 exists — felt it was worth submitting anyway, but aware the changes conflict. Feel free to close if you'd rather focus on that PR instead!

 - Mark all methods as executing on the main thread. This ensures that methods that interact with the Minecraft world (such as `getCachedCore` or `tile.flowOverridden`) are called from the Minecraft thread, rather than the Lua one.

 - Update capability code to fetch the peripheral via `CapabilityManager`. It might be worth refactoring some of this logic into a common base class (CC itself just has a [dedicated `ICapabilityProvider` impl](https://github.com/cc-tweaked/CC-Tweaked/blob/mc-1.20.x/projects/forge/src/main/java/dan200/computercraft/shared/util/CapabilityProvider.java)), but given that this goes away in 1.21, possibly not worth it.