### PR TITLE
Fix Apotheosis affix data not transfering during fusion crafting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,9 @@ repositories {
     }
     maven { url = "https://maven.blamejared.com/" }
 //    maven { url = "https://modmaven.dev/" }
+    maven { url = "https://maven.shadowsoffire.dev/releases"
+        content { includeGroup ("dev.shadowsoffire") }
+    }
 }
 
 dependencies {
@@ -95,6 +98,10 @@ dependencies {
 //    runtimeOnly fg.deobf("mekanism:Mekanism:1.18.2-10.2.5.465:additions")// Mekanism: Additions
 //    runtimeOnly fg.deobf("mekanism:Mekanism:1.18.2-10.2.5.465:generators")// Mekanism: Generators
 //    runtimeOnly fg.deobf("mekanism:Mekanism:1.18.2-10.2.5.465:tools")// Mekanism: Tools
+    // Apotheosis Testing
+//    runtimeOnly fg.deobf("dev.shadowsoffire:Apotheosis:1.20.1-7.4.3")
+//    runtimeOnly fg.deobf("dev.shadowsoffire:ApothicAttributes:1.20.1-1.3.7")
+//    runtimeOnly fg.deobf("dev.shadowsoffire:Placebo:1.20.1-8.6.2")
 }
 
 test {

--- a/src/main/java/com/brandon3055/draconicevolution/api/crafting/IFusionDataTransfer.java
+++ b/src/main/java/com/brandon3055/draconicevolution/api/crafting/IFusionDataTransfer.java
@@ -4,6 +4,7 @@ import com.brandon3055.brandonscore.api.power.IOPStorage;
 import com.brandon3055.draconicevolution.api.capability.DECapabilities;
 import com.brandon3055.draconicevolution.api.capability.ModuleHost;
 import com.brandon3055.draconicevolution.api.modules.lib.ModuleHostImpl;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraftforge.common.util.LazyOptional;
@@ -21,6 +22,13 @@ public interface IFusionDataTransfer {
                     result.enchant(enchant, level);
                 }
             });
+        }
+
+        if (cat.hasTag()) {
+            CompoundTag tag = cat.getTagElement("affix_data");
+            if (tag != null) {
+                result.addTagElement("affix_data", tag);
+            }
         }
 
         LazyOptional<ModuleHost> optCatHost = cat.getCapability(DECapabilities.MODULE_HOST_CAPABILITY);


### PR DESCRIPTION
We get the tag where Apotheosis saves an item's affix data and apply it to the result if its not null.
Fixes #1848  