### PR TITLE
[1.20] Fix render depth leak

### DIFF
--- a/src/main/java/com/brandon3055/draconicevolution/api/render/DERenderTypes.java
+++ b/src/main/java/com/brandon3055/draconicevolution/api/render/DERenderTypes.java
@@ -37,6 +37,13 @@ public class DERenderTypes {
         public void setupRenderState() {
             RenderSystem.disableDepthTest();
         }
+
+        @Override
+        public void clearRenderState() {
+            // The inherited clearRenderState is a no-op for func 519, so without this override
+            // the disableDepthTest() above leaks into all subsequent rendering.
+            RenderSystem.enableDepthTest();
+        }
     };
 
     public static final RenderType BOX_NO_DEPTH = RenderType.create("de:box_no_depth", DefaultVertexFormat.POSITION_COLOR, VertexFormat.Mode.QUADS, 256, false, true, RenderType.CompositeState.builder()
@@ -52,7 +59,7 @@ public class DERenderTypes {
             .setTransparencyState(RenderStateShard.TRANSLUCENT_TRANSPARENCY)
             .setCullState(RenderStateShard.NO_CULL)
             .setWriteMaskState(RenderStateShard.COLOR_WRITE)
-            .setDepthTestState(RenderStateShard.NO_DEPTH_TEST)
+            .setDepthTestState(DISABLE_DEPTH)
             .setLineState(new RenderStateShard.LineStateShard(OptionalDouble.of(4.0)))
             .createCompositeState(false)
     );

--- a/src/main/java/com/brandon3055/draconicevolution/client/AtlasTextureHelper.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/AtlasTextureHelper.java
@@ -44,6 +44,8 @@ public class AtlasTextureHelper {
 
     public static ParticleRenderType PARTICLE_SHEET_TRANSLUCENT = new ParticleRenderType() {
         public void begin(BufferBuilder builder, TextureManager manager) {
+            RenderSystem.enableDepthTest(); // Guard against depth test being left disabled (see CrystalFXBeam.FXHandler#begin)
+            Minecraft.getInstance().gameRenderer.lightTexture().turnOnLightLayer();
             RenderSystem.depthMask(false);
             RenderSystem.enableBlend();
             RenderSystem.blendFunc(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA);

--- a/src/main/java/com/brandon3055/draconicevolution/client/render/effect/CrystalFXBeam.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/render/effect/CrystalFXBeam.java
@@ -13,6 +13,7 @@ import com.mojang.blaze3d.platform.GlStateManager;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.*;
 import net.minecraft.client.Camera;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.particle.ParticleRenderType;
 import net.minecraft.client.renderer.GameRenderer;
@@ -185,6 +186,15 @@ public class CrystalFXBeam<T extends BlockEntity & IENetEffectTile> extends Crys
 
         @Override
         public void begin(BufferBuilder builder, TextureManager textureManager) {
+            // Depth testing may have been left disabled by a previously rendered particle type.
+            // e.g. vanilla's ItemPickupParticle (ParticleRenderType.CUSTOM) renders the picked up
+            // item entity mid particle-pass via MultiBufferSource#endBatch, and the entity render
+            // types' clearRenderState() leaves GL depth testing disabled. Without this guard the
+            // beams render through walls whenever an item pickup animation is on screen. (#2030)
+            // The same flush also unbinds the lightmap texture (LightmapStateShard#clearRenderState),
+            // so that gets re-bound here as well.
+            RenderSystem.enableDepthTest();
+            Minecraft.getInstance().gameRenderer.lightTexture().turnOnLightLayer();
             RenderSystem.setShader(GameRenderer::getPositionColorTexLightmapShader);
             RenderSystem.disableCull();
             RenderSystem.depthMask(false);

--- a/src/main/java/com/brandon3055/draconicevolution/client/render/effect/CrystalFXIO.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/render/effect/CrystalFXIO.java
@@ -6,6 +6,7 @@ import com.mojang.blaze3d.platform.GlStateManager;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.*;
 import net.minecraft.client.Camera;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.particle.ParticleRenderType;
 import net.minecraft.client.renderer.GameRenderer;
@@ -76,6 +77,8 @@ public class CrystalFXIO extends CrystalFXBase<TileCrystalBase> {
 
         @Override
         public void begin(BufferBuilder builder, TextureManager textureManager) {
+            RenderSystem.enableDepthTest(); // Guard against depth test being left disabled (see CrystalFXBeam.FXHandler#begin)
+            Minecraft.getInstance().gameRenderer.lightTexture().turnOnLightLayer();
             RenderSystem.depthMask(false);
             RenderSystem.enableBlend();
             RenderSystem.blendFunc(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE);

--- a/src/main/java/com/brandon3055/draconicevolution/client/render/effect/CrystalFXLink.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/render/effect/CrystalFXLink.java
@@ -12,6 +12,7 @@ import com.mojang.blaze3d.platform.GlStateManager;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.*;
 import net.minecraft.client.Camera;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.particle.ParticleRenderType;
 import net.minecraft.client.renderer.GameRenderer;
@@ -150,6 +151,8 @@ public class CrystalFXLink extends CrystalFXBase<TileCrystalBase> {
 
         @Override
         public void begin(BufferBuilder builder, TextureManager textureManager) {
+            RenderSystem.enableDepthTest(); // Guard against depth test being left disabled (see CrystalFXBeam.FXHandler#begin)
+            Minecraft.getInstance().gameRenderer.lightTexture().turnOnLightLayer();
             RenderSystem.disableCull();
             RenderSystem.depthMask(false);
             RenderSystem.enableBlend();

--- a/src/main/java/com/brandon3055/draconicevolution/client/render/effect/CrystalFXRing.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/render/effect/CrystalFXRing.java
@@ -8,6 +8,7 @@ import com.mojang.blaze3d.platform.GlStateManager;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.*;
 import net.minecraft.client.Camera;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.particle.ParticleRenderType;
 import net.minecraft.client.renderer.GameRenderer;
@@ -155,6 +156,8 @@ public class CrystalFXRing extends CrystalFXBase<TileCrystalBase> {
     public static final ParticleRenderType RENDER_TYPE = new ParticleRenderType() {
         @Override
         public void begin(BufferBuilder builder, TextureManager textureManager) {
+            RenderSystem.enableDepthTest(); // Guard against depth test being left disabled (see CrystalFXBeam.FXHandler#begin)
+            Minecraft.getInstance().gameRenderer.lightTexture().turnOnLightLayer();
             RenderSystem.depthMask(false);
             RenderSystem.enableBlend();
             RenderSystem.blendFunc(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE);

--- a/src/main/java/com/brandon3055/draconicevolution/client/render/effect/CrystalFXWireless.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/render/effect/CrystalFXWireless.java
@@ -129,6 +129,8 @@ public class CrystalFXWireless extends CrystalFXBase<TileCrystalWirelessIO> {
     public static class FXHandler implements ParticleRenderType {
         @Override
         public void begin(BufferBuilder builder, TextureManager textureManager) {
+            RenderSystem.enableDepthTest(); // Guard against depth test being left disabled (see CrystalFXBeam.FXHandler#begin)
+            Minecraft.getInstance().gameRenderer.lightTexture().turnOnLightLayer();
             RenderSystem.depthMask(false);
             RenderSystem.enableBlend();
             RenderSystem.blendFunc(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE);

--- a/src/main/java/com/brandon3055/draconicevolution/client/render/effect/ExplosionFX.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/render/effect/ExplosionFX.java
@@ -56,6 +56,13 @@ public class ExplosionFX extends Particle {
         public void setupRenderState() {
             RenderSystem.disableDepthTest();
         }
+
+        @Override
+        public void clearRenderState() {
+            // The inherited clearRenderState is a no-op for func 519, so without this override
+            // the disableDepthTest() above leaks into all subsequent rendering.
+            RenderSystem.enableDepthTest();
+        }
     };
 
     public static RenderType EXPLOSION_TYPE = RenderType.create(MODID + ":explosion_shader", DefaultVertexFormat.POSITION_TEX, VertexFormat.Mode.QUADS, 256, false, true, RenderType.CompositeState.builder()

--- a/src/main/java/com/brandon3055/draconicevolution/client/render/effect/StaffBeamEffect.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/render/effect/StaffBeamEffect.java
@@ -135,6 +135,7 @@ public class StaffBeamEffect extends Particle {
         @Override
         public void begin(BufferBuilder builder, TextureManager textureManager) {
             textureManager.bindForSetup(texture);
+            RenderSystem.enableDepthTest(); // Guard against depth test being left disabled (see CrystalFXBeam.FXHandler#begin)
             RenderSystem.disableCull();
             RenderSystem.depthMask(false);
             RenderSystem.enableBlend();

--- a/src/main/java/com/brandon3055/draconicevolution/client/render/particle/ParticleEnergyCoreFX.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/render/particle/ParticleEnergyCoreFX.java
@@ -11,6 +11,7 @@ import com.mojang.blaze3d.vertex.BufferBuilder;
 import com.mojang.blaze3d.vertex.DefaultVertexFormat;
 import com.mojang.blaze3d.vertex.Tesselator;
 import com.mojang.blaze3d.vertex.VertexFormat;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.particle.*;
 import net.minecraft.client.renderer.GameRenderer;
@@ -26,6 +27,8 @@ public class ParticleEnergyCoreFX extends TextureSheetParticle {
 
     public static final ParticleRenderType PARTICLE_NO_DEPTH_NO_LIGHT = new ParticleRenderType() {
         public void begin(BufferBuilder builder, TextureManager manager) {
+            RenderSystem.enableDepthTest(); // Guard against depth test being left disabled (see CrystalFXBeam.FXHandler#begin)
+            Minecraft.getInstance().gameRenderer.lightTexture().turnOnLightLayer();
             RenderSystem.depthMask(false);
 //            RenderSystem.setShader(GameRenderer::getParticleShader);
             RenderSystem.setShaderTexture(0, TextureAtlas.LOCATION_PARTICLES);

--- a/src/main/java/com/brandon3055/draconicevolution/client/render/particle/ParticleLineIndicator.java
+++ b/src/main/java/com/brandon3055/draconicevolution/client/render/particle/ParticleLineIndicator.java
@@ -7,6 +7,7 @@ import com.mojang.blaze3d.vertex.BufferBuilder;
 import com.mojang.blaze3d.vertex.DefaultVertexFormat;
 import com.mojang.blaze3d.vertex.Tesselator;
 import com.mojang.blaze3d.vertex.VertexFormat;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.particle.*;
 import net.minecraft.client.renderer.GameRenderer;
@@ -21,6 +22,8 @@ import net.minecraft.world.level.Level;
 public class ParticleLineIndicator extends TextureSheetParticle {
     public static final ParticleRenderType PARTICLE_NO_DEPTH_NO_LIGHT = new ParticleRenderType() {
         public void begin(BufferBuilder builder, TextureManager manager) {
+            RenderSystem.enableDepthTest(); // Guard against depth test being left disabled (see CrystalFXBeam.FXHandler#begin)
+            Minecraft.getInstance().gameRenderer.lightTexture().turnOnLightLayer();
             RenderSystem.depthMask(false);
 //            RenderSystem.setShader(GameRenderer::getParticleShader);
             RenderSystem.setShaderTexture(0, TextureAtlas.LOCATION_PARTICLES);


### PR DESCRIPTION
Fix render depth leak which causes energy crystals and some other particles to render thru solid objects when they should not.

Most often happens when picking up dropped items but other sources can trigger it.

This issue is documented in #2030 and I assume is the same or similar issue, although this PR only fixes it for 1.20.1. I am sure this fix could be ported quite easily to other versions of DE.

I have tested this in Singleplayer and SMP with no issues for about ~8h of gameplay.